### PR TITLE
Support PCM -> fbank transform inside tensorflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --max-complexity 10 --max-line-length 127 --statistics
+        flake8 . --count --ignore=E203 --max-complexity 10 --max-line-length 127 --statistics
     - name: Test with tox
       run: |
         tox

--- a/conv_models.py
+++ b/conv_models.py
@@ -4,18 +4,20 @@ import os
 import numpy as np
 import tensorflow as tf
 import tensorflow.keras.backend as K
-from tensorflow.keras import layers
-from tensorflow.keras import regularizers
-from tensorflow.keras.layers import BatchNormalization
-from tensorflow.keras.layers import Conv2D
-from tensorflow.keras.layers import Dropout
-from tensorflow.keras.layers import Input
-from tensorflow.keras.layers import Lambda, Dense
-from tensorflow.keras.layers import Reshape
+from tensorflow.keras import layers, regularizers
+from tensorflow.keras.layers import (
+    BatchNormalization,
+    Conv2D,
+    Dense,
+    Dropout,
+    Input,
+    Lambda,
+    Reshape,
+)
 from tensorflow.keras.models import Model
 from tensorflow.keras.optimizers import Adam
 
-from constants import NUM_FBANKS, NUM_FRAMES, SAMPLE_RATE
+from constants import NUM_FBANKS, SAMPLE_RATE
 from triplet_loss import deep_speaker_loss
 
 logger = logging.getLogger(__name__)
@@ -27,8 +29,13 @@ class DeepSpeakerModel:
     # would be better to have 4 dimensions:
     # MFCC, DIFF(MFCC), DIFF(DIFF(MFCC)), ENERGIES (probably tiled across the frequency domain).
     # this seems to help match the parameter counts.
-    def __init__(self, batch_input_shape=None, include_softmax=False,
-                 num_speakers_softmax=None, pcm_input=False):
+    def __init__(
+        self,
+        batch_input_shape=None,
+        include_softmax=False,
+        num_speakers_softmax=None,
+        pcm_input=False,
+    ):
         self.include_softmax = include_softmax
         if self.include_softmax:
             assert num_speakers_softmax > 0
@@ -51,34 +58,37 @@ class DeepSpeakerModel:
         # num_frames = K.shape() - do it dynamically after.
 
         if pcm_input:
-            batch_input_shape = batch_input_shape or (None, None)  # Batch-size, num-samples
-            inputs = Input(batch_shape=batch_input_shape, name='raw_inputs')
+            batch_input_shape = batch_input_shape or (
+                None,
+                None,
+            )  # Batch-size, num-samples
+            inputs = Input(batch_shape=batch_input_shape, name="raw_inputs")
             x = inputs
             x = Lambda(tf_fbank)(x)
             x = Lambda(lambda x: tf_normalize(x, 1, 1e-12))(x)
             x = Lambda(lambda x: tf.expand_dims(x, axis=-1))(x)
         else:
             batch_input_shape = batch_input_shape or (None, None, NUM_FBANKS, 1)
-            inputs = Input(batch_shape=batch_input_shape, name='input')
+            inputs = Input(batch_shape=batch_input_shape, name="input")
             x = inputs
 
         x = self.cnn_component(x)
 
         x = Reshape((-1, 2048))(x)
         # Temporal average layer. axis=1 is time.
-        x = Lambda(lambda y: K.mean(y, axis=1), name='average')(x)
+        x = Lambda(lambda y: K.mean(y, axis=1), name="average")(x)
         if include_softmax:
-            logger.info('Including a Dropout layer to reduce overfitting.')
+            logger.info("Including a Dropout layer to reduce overfitting.")
             # used for softmax because the dataset we pre-train on might be too small. easy to overfit.
             x = Dropout(0.5)(x)
-        x = Dense(512, name='affine')(x)
+        x = Dense(512, name="affine")(x)
         if include_softmax:
             # Those weights are just when we train on softmax.
-            x = Dense(num_speakers_softmax, activation='softmax')(x)
+            x = Dense(num_speakers_softmax, activation="softmax")(x)
         else:
             # Does not contain any weights.
-            x = Lambda(lambda y: K.l2_normalize(y, axis=1), name='ln')(x)
-        self.m = Model(inputs, x, name='ResCNN')
+            x = Lambda(lambda y: K.l2_normalize(y, axis=1), name="ln")(x)
+        self.m = Model(inputs, x, name="ResCNN")
 
     def keras_model(self):
         return self.m
@@ -91,33 +101,40 @@ class DeepSpeakerModel:
         return w
 
     def clipped_relu(self, inputs):
-        relu = Lambda(lambda y: K.minimum(K.maximum(y, 0), 20), name=f'clipped_relu_{self.clipped_relu_count}')(inputs)
+        relu = Lambda(
+            lambda y: K.minimum(K.maximum(y, 0), 20),
+            name=f"clipped_relu_{self.clipped_relu_count}",
+        )(inputs)
         self.clipped_relu_count += 1
         return relu
 
     def identity_block(self, input_tensor, kernel_size, filters, stage, block):
-        conv_name_base = f'res{stage}_{block}_branch'
+        conv_name_base = f"res{stage}_{block}_branch"
 
-        x = Conv2D(filters,
-                   kernel_size=kernel_size,
-                   strides=1,
-                   activation=None,
-                   padding='same',
-                   kernel_initializer='glorot_uniform',
-                   kernel_regularizer=regularizers.l2(l=0.0001),
-                   name=conv_name_base + '_2a')(input_tensor)
-        x = BatchNormalization(name=conv_name_base + '_2a_bn')(x)
+        x = Conv2D(
+            filters,
+            kernel_size=kernel_size,
+            strides=1,
+            activation=None,
+            padding="same",
+            kernel_initializer="glorot_uniform",
+            kernel_regularizer=regularizers.l2(l=0.0001),
+            name=conv_name_base + "_2a",
+        )(input_tensor)
+        x = BatchNormalization(name=conv_name_base + "_2a_bn")(x)
         x = self.clipped_relu(x)
 
-        x = Conv2D(filters,
-                   kernel_size=kernel_size,
-                   strides=1,
-                   activation=None,
-                   padding='same',
-                   kernel_initializer='glorot_uniform',
-                   kernel_regularizer=regularizers.l2(l=0.0001),
-                   name=conv_name_base + '_2b')(x)
-        x = BatchNormalization(name=conv_name_base + '_2b_bn')(x)
+        x = Conv2D(
+            filters,
+            kernel_size=kernel_size,
+            strides=1,
+            activation=None,
+            padding="same",
+            kernel_initializer="glorot_uniform",
+            kernel_regularizer=regularizers.l2(l=0.0001),
+            name=conv_name_base + "_2b",
+        )(x)
+        x = BatchNormalization(name=conv_name_base + "_2b_bn")(x)
 
         x = self.clipped_relu(x)
 
@@ -126,19 +143,24 @@ class DeepSpeakerModel:
         return x
 
     def conv_and_res_block(self, inp, filters, stage):
-        conv_name = 'conv{}-s'.format(filters)
+        conv_name = "conv{}-s".format(filters)
         # TODO: why kernel_regularizer?
-        o = Conv2D(filters,
-                   kernel_size=5,
-                   strides=2,
-                   activation=None,
-                   padding='same',
-                   kernel_initializer='glorot_uniform',
-                   kernel_regularizer=regularizers.l2(l=0.0001), name=conv_name)(inp)
-        o = BatchNormalization(name=conv_name + '_bn')(o)
+        o = Conv2D(
+            filters,
+            kernel_size=5,
+            strides=2,
+            activation=None,
+            padding="same",
+            kernel_initializer="glorot_uniform",
+            kernel_regularizer=regularizers.l2(l=0.0001),
+            name=conv_name,
+        )(inp)
+        o = BatchNormalization(name=conv_name + "_bn")(o)
         o = self.clipped_relu(o)
         for i in range(3):
-            o = self.identity_block(o, kernel_size=3, filters=filters, stage=stage, block=i)
+            o = self.identity_block(
+                o, kernel_size=3, filters=filters, stage=stage, block=i
+            )
         return o
 
     def cnn_component(self, inp):
@@ -151,7 +173,7 @@ class DeepSpeakerModel:
     def set_weights(self, w):
         for layer, layer_w in zip(self.m.layers, w):
             layer.set_weights(layer_w)
-            logger.info(f'Setting weights for [{layer.name}]...')
+            logger.info(f"Setting weights for [{layer.name}]...")
 
 
 def main():
@@ -195,29 +217,33 @@ def _train():
     batch = np.vstack((negative, negative, negative))
     x = batch
     y = np.zeros(shape=(len(batch), 512))  # not important.
-    print('Starting to fit...')
+    print("Starting to fit...")
     while True:
         print(dsm.m.train_on_batch(x, y))
 
 
 def _test_checkpoint_compatibility():
-    dsm = DeepSpeakerModel(batch_input_shape=(None, 32, 64, 4), include_softmax=True, num_speakers_softmax=10)
-    dsm.m.save_weights('test.h5')
+    dsm = DeepSpeakerModel(
+        batch_input_shape=(None, 32, 64, 4),
+        include_softmax=True,
+        num_speakers_softmax=10,
+    )
+    dsm.m.save_weights("test.h5")
     dsm = DeepSpeakerModel(batch_input_shape=(None, 32, 64, 4), include_softmax=False)
-    dsm.m.load_weights('test.h5', by_name=True)
-    os.remove('test.h5')
+    dsm.m.load_weights("test.h5", by_name=True)
+    os.remove("test.h5")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     _test_checkpoint_compatibility()
 
-    
+
 @tf.function
 def tf_normalize(data, ndims, eps=0, adjusted=False):
-    data = tf.convert_to_tensor(data, name='data')
+    data = tf.convert_to_tensor(data, name="data")
 
-    reduce_dims = [- i - 1 for i in range(ndims)]
-    
+    reduce_dims = [-i - 1 for i in range(ndims)]
+
     data = tf.cast(data, dtype=tf.dtypes.float32)
     data_num = tf.reduce_prod(data.shape[-ndims:])
     data_mean = tf.reduce_mean(data, axis=reduce_dims, keepdims=True)
@@ -233,6 +259,7 @@ def tf_normalize(data, ndims, eps=0, adjusted=False):
 
     return (data - data_mean) / adjusted_stddev
 
+
 @tf.function
 def tf_fbank(samples):
     """
@@ -244,35 +271,38 @@ def tf_fbank(samples):
     fft_length = 512
     fft_bins = fft_length // 2 + 1
 
-    preemphasis = samples[:,1:] - 0.97 * samples[:, :-1]
-    
-    # Original implementation from python_speech_features
-    #frames = tf.expand_dims(sigproc.framesig(preemphasis[0], frame_length, frame_step, winfunc=lambda x: np.ones((x,))), 0)
-    #powspec = sigproc.powspec(frames, fft_length)
-        
-    # Tensorflow impl #1, using manually-split frames and rfft
-    #spec = tf.abs(tf.signal.rfft(frames, [fft_length]))
-    #powspec = tf.square(spec) / fft_length
+    preemphasis = samples[:, 1:] - 0.97 * samples[:, :-1]
 
-    # Tensorflow impl #2, using stft to handle framing automatically 
+    # Original implementation from python_speech_features
+    # frames = tf.expand_dims(sigproc.framesig(preemphasis[0], frame_length, frame_step, winfunc=lambda x: np.ones((x,))), 0)
+    # powspec = sigproc.powspec(frames, fft_length)
+
+    # Tensorflow impl #1, using manually-split frames and rfft
+    # spec = tf.abs(tf.signal.rfft(frames, [fft_length]))
+    # powspec = tf.square(spec) / fft_length
+
+    # Tensorflow impl #2, using stft to handle framing automatically
     # (There is a one-off mismatch on the number of frames on the resulting tensor, but I guess this is ok)
-    spec = tf.abs(tf.signal.stft(preemphasis, frame_length, frame_step, fft_length, window_fn=tf.ones))
+    spec = tf.abs(
+        tf.signal.stft(
+            preemphasis, frame_length, frame_step, fft_length, window_fn=tf.ones
+        )
+    )
     powspec = tf.square(spec) / fft_length
-    
-    
+
     # Matrix to transform spectrum to mel-frequencies
-    
+
     # Original implementation from python_speech_features
     # linear_to_mel_weight_matrix = get_filterbanks(NUM_FBANKS, fft_length, SAMPLE_RATE, 0, SAMPLE_RATE/2).astype(np.float32).T
-    
+
     linear_to_mel_weight_matrix = tf.signal.linear_to_mel_weight_matrix(
-        num_mel_bins=NUM_FBANKS, 
+        num_mel_bins=NUM_FBANKS,
         num_spectrogram_bins=fft_bins,
         sample_rate=SAMPLE_RATE,
-        lower_edge_hertz=0, 
-        upper_edge_hertz=SAMPLE_RATE / 2)
-    
-    feat = tf.matmul(powspec, linear_to_mel_weight_matrix)
-    #feat = tf.where(feat == 0, np.finfo(np.float32).eps, feat)
-    return feat
+        lower_edge_hertz=0,
+        upper_edge_hertz=SAMPLE_RATE / 2,
+    )
 
+    feat = tf.matmul(powspec, linear_to_mel_weight_matrix)
+    # feat = tf.where(feat == 0, np.finfo(np.float32).eps, feat)
+    return feat

--- a/example.py
+++ b/example.py
@@ -1,12 +1,12 @@
 import random
+from test import batch_cosine_similarity
 
 import numpy as np
 
 from audio import read_mfcc
 from batcher import sample_from_mfcc
-from constants import SAMPLE_RATE, NUM_FRAMES
+from constants import NUM_FRAMES, SAMPLE_RATE
 from conv_models import DeepSpeakerModel
-from test import batch_cosine_similarity
 
 # Reproducible results.
 np.random.seed(123)
@@ -16,27 +16,33 @@ random.seed(123)
 model = DeepSpeakerModel()
 
 # Load the checkpoint.
-model.m.load_weights('ResCNN_triplet_training_checkpoint_265.h5', by_name=True)
+model.m.load_weights("ResCNN_triplet_training_checkpoint_265.h5", by_name=True)
 
 # Sample some inputs for WAV/FLAC files for the same speaker.
 # To have reproducible results every time you call this function, set the seed every time before calling it.
 # np.random.seed(123)
 # random.seed(123)
-mfcc_001 = sample_from_mfcc(read_mfcc('samples/PhilippeRemy/PhilippeRemy_001.wav', SAMPLE_RATE), NUM_FRAMES)
-mfcc_002 = sample_from_mfcc(read_mfcc('samples/PhilippeRemy/PhilippeRemy_002.wav', SAMPLE_RATE), NUM_FRAMES)
+mfcc_001 = sample_from_mfcc(
+    read_mfcc("samples/PhilippeRemy/PhilippeRemy_001.wav", SAMPLE_RATE), NUM_FRAMES
+)
+mfcc_002 = sample_from_mfcc(
+    read_mfcc("samples/PhilippeRemy/PhilippeRemy_002.wav", SAMPLE_RATE), NUM_FRAMES
+)
 
 # Call the model to get the embeddings of shape (1, 512) for each file.
 predict_001 = model.m.predict(np.expand_dims(mfcc_001, axis=0))
 predict_002 = model.m.predict(np.expand_dims(mfcc_002, axis=0))
 
 # Do it again with a different speaker.
-mfcc_003 = sample_from_mfcc(read_mfcc('samples/1255-90413-0001.flac', SAMPLE_RATE), NUM_FRAMES)
+mfcc_003 = sample_from_mfcc(
+    read_mfcc("samples/1255-90413-0001.flac", SAMPLE_RATE), NUM_FRAMES
+)
 predict_003 = model.m.predict(np.expand_dims(mfcc_003, axis=0))
 
 # Compute the cosine similarity and check that it is higher for the same speaker.
 same_speaker_similarity = batch_cosine_similarity(predict_001, predict_002)
 diff_speaker_similarity = batch_cosine_similarity(predict_001, predict_003)
-print('SAME SPEAKER', same_speaker_similarity)  # SAME SPEAKER [0.81564593]
-print('DIFF SPEAKER', diff_speaker_similarity)  # DIFF SPEAKER [0.1419204]
+print("SAME SPEAKER", same_speaker_similarity)  # SAME SPEAKER [0.81564593]
+print("DIFF SPEAKER", diff_speaker_similarity)  # DIFF SPEAKER [0.1419204]
 
 assert same_speaker_similarity > diff_speaker_similarity

--- a/example_pcm.py
+++ b/example_pcm.py
@@ -1,0 +1,41 @@
+import random
+
+import numpy as np
+import tensorflow as tf
+import librosa
+from constants import SAMPLE_RATE
+from conv_models import DeepSpeakerModel
+from test import batch_cosine_similarity
+
+# Define the model here.
+model = DeepSpeakerModel(pcm_input=True)
+
+# Load the checkpoint.
+model.m.load_weights('ResCNN_triplet_training_checkpoint_265.h5', by_name=True)
+
+pcm = [
+    librosa.load(x, sr=SAMPLE_RATE, mono=True)[0]
+    for x in [
+        'samples/PhilippeRemy/PhilippeRemy_001.wav',
+        'samples/PhilippeRemy/PhilippeRemy_002.wav',
+        'samples/1255-90413-0001.flac',
+    ]
+]
+    
+# Crop samples on the center, to fit the smalles audio sample
+num_samples = min([len(x) for x in pcm])
+pcm = tf.convert_to_tensor(np.stack([
+    x[(len(x) - num_samples) // 2:][:num_samples]
+    for x  in pcm
+]))
+# Call the model to get the embeddings of shape (1, 512) for each file.
+predict = model.m.predict(pcm)
+speaker_similarity = batch_cosine_similarity(predict[0:1], predict[1:])
+
+# Compute the cosine similarity and check that it is higher for the same speaker.
+same_speaker_similarity = speaker_similarity[0]
+diff_speaker_similarity = speaker_similarity[1]
+print('SAME SPEAKER', same_speaker_similarity)  # SAME SPEAKER [0.81564593]
+print('DIFF SPEAKER', diff_speaker_similarity)  # DIFF SPEAKER [0.1419204]
+
+assert same_speaker_similarity > diff_speaker_similarity

--- a/example_pcm.py
+++ b/example_pcm.py
@@ -1,33 +1,32 @@
-import random
+from test import batch_cosine_similarity
 
+import librosa
 import numpy as np
 import tensorflow as tf
-import librosa
+
 from constants import SAMPLE_RATE
 from conv_models import DeepSpeakerModel
-from test import batch_cosine_similarity
 
 # Define the model here.
 model = DeepSpeakerModel(pcm_input=True)
 
 # Load the checkpoint.
-model.m.load_weights('ResCNN_triplet_training_checkpoint_265.h5', by_name=True)
+model.m.load_weights("ResCNN_triplet_training_checkpoint_265.h5", by_name=True)
 
 pcm = [
     librosa.load(x, sr=SAMPLE_RATE, mono=True)[0]
     for x in [
-        'samples/PhilippeRemy/PhilippeRemy_001.wav',
-        'samples/PhilippeRemy/PhilippeRemy_002.wav',
-        'samples/1255-90413-0001.flac',
+        "samples/PhilippeRemy/PhilippeRemy_001.wav",
+        "samples/PhilippeRemy/PhilippeRemy_002.wav",
+        "samples/1255-90413-0001.flac",
     ]
 ]
-    
+
 # Crop samples on the center, to fit the smalles audio sample
 num_samples = min([len(x) for x in pcm])
-pcm = tf.convert_to_tensor(np.stack([
-    x[(len(x) - num_samples) // 2:][:num_samples]
-    for x  in pcm
-]))
+pcm = tf.convert_to_tensor(
+    np.stack([x[(len(x) - num_samples) // 2 :][:num_samples] for x in pcm])
+)
 # Call the model to get the embeddings of shape (1, 512) for each file.
 predict = model.m.predict(pcm)
 speaker_similarity = batch_cosine_similarity(predict[0:1], predict[1:])
@@ -35,7 +34,7 @@ speaker_similarity = batch_cosine_similarity(predict[0:1], predict[1:])
 # Compute the cosine similarity and check that it is higher for the same speaker.
 same_speaker_similarity = speaker_similarity[0]
 diff_speaker_similarity = speaker_similarity[1]
-print('SAME SPEAKER', same_speaker_similarity)  # SAME SPEAKER [0.81564593]
-print('DIFF SPEAKER', diff_speaker_similarity)  # DIFF SPEAKER [0.1419204]
+print("SAME SPEAKER", same_speaker_similarity)  # SAME SPEAKER [0.81564593]
+print("DIFF SPEAKER", diff_speaker_similarity)  # DIFF SPEAKER [0.1419204]
 
 assert same_speaker_similarity > diff_speaker_similarity


### PR DESCRIPTION
I'm attempting to export the model and use it in a non-python app.

While the tensorlow model is quite portable, the input pre-processing (audio.mfcc_fbank) is not.
    
This PR adds support to moving this stage into tensorflow by adding `pcm_input=True` when building the model.
    
When this is set, the input becomes a tensor with raw PCM data and shape [batch_size, num_samples].
    
The implementation attempts to be as close as possible to the original, however due to the different implementations/libraries, the results do differ a little bit.
    
The PR also provides `example_pcm.py`, a modified version of example.py which uses raw PCM inputs and batched tensorflow operations