### PR TITLE
Remove explicit dependency on scipy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,5 @@ pandas>=1.0.3
 matplotlib>=3.2.1
 tensorflow>=2.3.0
 Keras>=2.3.1
-scipy<1.6.0
 numpy>=1.18.2
 numba>=0.48


### PR DESCRIPTION
I was having trouble installing dependencies on a new machine because deep-speaker has a dependency on an older version of scipy (<1.6).

Turns out deep-speaker doesn't even use scipy -- At least not directly: librosa does use it, but it is apparently happy with the newest version.